### PR TITLE
 feat: Added musgravite powershell script

### DIFF
--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -12,6 +12,25 @@ function Display-Menu {
 
 
 
+param(
+    [string]$arg = ""
+)
+
+
+
+if ($arg -eq "-c") {
+    Musgravite-C
+    exit 0
+}
+elseif ($arg -eq "-cpp") {
+    Musgravite-Cpp
+    exit 0
+}
+
+
+
+
+
 while ($true) {
     Display-Menu
 

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -105,6 +105,27 @@ function Musgravite-C {
 
 
 
+function Musgravite-Cpp {
+    Create-WorkSpace
+
+    if (Test-Path ".\musgravite\musgravite.hpp" -PathType Leaf) {
+        Move-Item -Path ".\musgravite\musgravite.hpp" -Destination "..\_libs\musgravite"
+    }
+    else {
+        Write-Host "Error: File 'musgravite.hpp' not found."
+        return
+    }
+
+    $option = Read-Host "Do you want to use a pre-configured make file for testing? [Y / N]"
+    if ($option -eq 'Y') {
+        Choose-Cpp-Compiler
+    }
+
+    Remove-Musgravite-Repo
+}
+
+
+
 
 
 param(

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -60,6 +60,22 @@ function Choose-Cpp-Compiler {
 
 
 
+function Remove-Musgravite-Repo {
+    Write-Host "The installation was successful."
+    $option = Read-Host "Do you want to remove the official musgravite repository from your workflow? [Y / N]"
+
+    if ($option -eq 'Y') {
+        if (Test-Path "..\Musgravite" -PathType Container) {
+            Remove-Item -Path "..\Musgravite" -Recurse -Force
+        }
+        else {
+            Write-Host "Musgravite repository not found."
+        }
+    }
+}
+
+
+
 
 
 param(

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -24,6 +24,24 @@ function Create-WorkSpace {
 
 
 
+function Choose-C-Compiler {
+    Write-Host "Which compiler do you want to use for C?"
+    Write-Host "1) GCC"
+    Write-Host "2) Clang"
+
+    $option = Read-Host "Enter the option number"
+
+    switch ($option) {
+        1 { $env:CC = "gcc" }
+        2 { $env:CC = "clang" }
+        Default { Write-Host "Invalid option. Defaulting to GCC."; $env:CC = "gcc" }
+    }
+
+    Move-Item -Path ".\helpers\make" -Destination "..\"
+}
+
+
+
 
 
 param(

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -1,0 +1,26 @@
+function Display-Menu {
+    Write-Host "`n`n-------------------- Musgravite --------------------`n"
+    Write-Host "1) Use musgravite with C"
+    Write-Host "2) Use musgravite with C++"
+    Write-Host "3) Use musgravite with D"
+    Write-Host "4) Use musgravite with Nim"
+    Write-Host "0) Exit"
+    Write-Host "`n----------------------------------------------------`n`n"
+}
+
+
+
+
+
+while ($true) {
+    Display-Menu
+
+    $option = Read-Host "Enter the option number"
+
+    switch ($option) {
+        1 { Musgravite-C }
+        2 { Musgravite-Cpp }
+        0 { Write-Host "Exiting..."; exit 0 }
+        Default { Write-Host "Invalid option. Please try again." }
+    }
+}

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -10,6 +10,20 @@ function Display-Menu {
 
 
 
+function Create-WorkSpace {
+    $musgravitePath = Join-Path "..\_libs" "musgravite"
+    $testsPath = Join-Path "..\_tests"
+
+    if (!(Test-Path $musgravitePath)) {
+        New-Item -ItemType Directory -Path $musgravitePath | Out-Null
+    }
+    if (!(Test-Path $testsPath)) {
+        New-Item -ItemType Directory -Path $testsPath | Out-Null
+    }
+}
+
+
+
 
 
 param(

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -42,6 +42,24 @@ function Choose-C-Compiler {
 
 
 
+function Choose-Cpp-Compiler {
+    Write-Host "Which compiler do you want to use for C++?"
+    Write-Host "1) G++"
+    Write-Host "2) Clang++"
+
+    $option = Read-Host "Enter the option number"
+
+    switch ($option) {
+        1 { $env:CXX = "g++" }
+        2 { $env:CXX = "clang++" }
+        Default { Write-Host "Invalid option. Defaulting to G++."; $env:CXX = "g++" }
+    }
+
+    Move-Item -Path ".\helpers\make++" -Destination "..\make"
+}
+
+
+
 
 
 param(

--- a/musgravite.ps1
+++ b/musgravite.ps1
@@ -76,6 +76,35 @@ function Remove-Musgravite-Repo {
 
 
 
+function Musgravite-C {
+    Create-WorkSpace
+
+    if (Test-Path ".\musgravite\C Wrapper" -PathType Container) {
+        Move-Item -Path ".\musgravite\C Wrapper\*" -Destination "..\_libs\musgravite"
+    }
+    else {
+        Write-Host "Error: Directory 'C Wrapper' not found."
+        return
+    }
+
+    if (Test-Path ".\musgravite\musgravite.hpp" -PathType Leaf) {
+        Move-Item -Path ".\musgravite\musgravite.hpp" -Destination "..\_libs\musgravite"
+    }
+    else {
+        Write-Host "Error: File 'musgravite.hpp' not found."
+        return
+    }
+
+    $option = Read-Host "Do you want to use a pre-configured make file for testing? [Y / N]"
+    if ($option -eq 'Y') {
+        Choose-C-Compiler
+    }
+
+    Remove-Musgravite-Repo
+}
+
+
+
 
 
 param(


### PR DESCRIPTION
I've added a PowerShell script to make it easier to integrate Musgravite into C and C++ projects. The script offers options for configuring the development environment, choosing compilers and managing the files needed to use Musgravite.

## Added Features:
- Interactive Menu: I have implemented an interactive menu that allows the user to choose between different configuration options for using Musgravite with C and C++.
- Compiler Configuration: I've included functions for choosing between GCC and Clang for C, and between G++ and Clang++ for C++.
- Repository Management: I've added the option to remove the official Musgravite repository after installation, if desired.
- Workspace creation: I've implemented a function to create the necessary directories (\_libs\musgravite and \_tests) if they don't exist.
- Moving Files: I've added functionality to move specific files (such as musgravite.hpp) to the Musgravite installation directory.