### PR TITLE
docs: Add Documentation for ADD_TEST_C Function and Variants

### DIFF
--- a/docs/C/AddTests.md
+++ b/docs/C/AddTests.md
@@ -139,3 +139,15 @@ To add a test with setup, teardown, and timeout:
     }
 ```
 - **Setup function and Timeout:** Combines setup function and timeout for the test.
+
+### Test with Teardown and Timeout
+```Cpp
+    void ADD_TEST_TEARDOWN_TIMEOUT_C(const char* suite, const char* test, void (*func)(void), void (*teardown)(void), int timeout) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, nullptr, teardown, std::chrono::seconds(timeout));
+    }
+```
+- **Teardown function and Timeout:** Combines teardown function and timeout for the test.

--- a/docs/C/AddTests.md
+++ b/docs/C/AddTests.md
@@ -151,3 +151,17 @@ To add a test with setup, teardown, and timeout:
     }
 ```
 - **Teardown function and Timeout:** Combines teardown function and timeout for the test.
+
+### Test with Setup, Teardown, and Timeout
+```Cpp
+    void ADD_TEST_SETUP_TEARDOWN_TIMEOUT_C(const char* suite, const char* test, void (*func)(void), void (*setup)(void), void (*teardown)(void), int timeout) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, setup, teardown, std::chrono::seconds(timeout));
+    }
+```
+- **Setup, Teardown, and Timeout:** Combines setup function, teardown function, and timeout for the test.
+
+<br>

--- a/docs/C/AddTests.md
+++ b/docs/C/AddTests.md
@@ -165,3 +165,8 @@ To add a test with setup, teardown, and timeout:
 - **Setup, Teardown, and Timeout:** Combines setup function, teardown function, and timeout for the test.
 
 <br>
+
+## Important Notes
+- **Initialization Requirement:** Ensure that `initializeMusgraviteRunner` is called before using any of the `ADD_TEST_C` functions to properly initialize the `global_runner`.
+- **Safety Checks:** Each function checks if `global_runner` is *null* before attempting to add a test, ensuring that no operations are performed on an uninitialized runner.
+- **Function Variants:** Choose the appropriate function variant based on the requirements of your test, such as the need for setup, teardown, and/or timeout.

--- a/docs/C/AddTests.md
+++ b/docs/C/AddTests.md
@@ -127,3 +127,15 @@ To add a test with setup, teardown, and timeout:
     }
 ```
 - **Setup and Teardown functions:** Combines both setup and teardown functions for the test.
+
+### Test with Setup and Timeout
+```Cpp
+    void ADD_TEST_SETUP_TIMEOUT_C(const char* suite, const char* test, void (*func)(void), void (*setup)(void), int timeout) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, setup, nullptr, std::chrono::seconds(timeout));
+    }
+```
+- **Setup function and Timeout:** Combines setup function and timeout for the test.

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -28,3 +28,10 @@ To add a test with a setup function:
 ```C    
     ADD_TEST_SETUP_C("suiteName", "testName", testFunction, setupFunction);
 ```
+
+### Test with Teardown
+To add a test with a teardown function:
+
+```C    
+    ADD_TEST_TEARDOWN_C("suiteName", "testName", testFunction, teardownFunction);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -1,0 +1,4 @@
+# ADD_TEST_C and Variants
+In this tutorial, you'll learn everything you need to know about the `ADD_TEST_C` function and its variants for adding tests in *C*.
+
+<br>

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -63,3 +63,20 @@ To add a test with setup, teardown, and timeout:
 ```C
     ADD_TEST_SETUP_TEARDOWN_TIMEOUT_C("suiteName", "testName", testFunction, setupFunction, teardownFunction, timeoutInSeconds);
 ```
+
+<br>
+
+## What do these functions do?
+### Basic Test Addition
+```Cpp
+    void ADD_TEST_C(const char* suite, const char* test, void (*func)(void)) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func);
+    }
+```
+
+- **Null pointer check:** Checks if `global_runner` is *null*.
+- **Test addition:** Adds the test to the `runner` if `global_runner` is initialized.

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -7,3 +7,10 @@ In this tutorial, you'll learn everything you need to know about the `ADD_TEST_C
 `ADD_TEST_C` and its variants are functions used to add tests to the `MusgraviteRunner` in the *C* environment. These functions ensure that tests are registered with various configurations such as setup, teardown, and timeout options.
 
 <br>
+
+## Basic Test Addition
+To add a basic test without setup, teardown, or timeout:
+
+```C    
+    ADD_TEST_C("suiteName", "testName", testFunction);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -56,3 +56,10 @@ To add a test with both teardown function and timeout:
 ```C
     ADD_TEST_TEARDOWN_TIMEOUT_C("suiteName", "testName", testFunction, teardownFunction, timeoutInSeconds);
 ```
+
+### Test with Setup, Teardown, and Timeout
+To add a test with setup, teardown, and timeout:
+
+```C
+    ADD_TEST_SETUP_TEARDOWN_TIMEOUT_C("suiteName", "testName", testFunction, setupFunction, teardownFunction, timeoutInSeconds);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -35,3 +35,10 @@ To add a test with a teardown function:
 ```C    
     ADD_TEST_TEARDOWN_C("suiteName", "testName", testFunction, teardownFunction);
 ```
+
+### Test with Setup and Teardown
+To add a test with both setup and teardown functions:
+
+```C    
+    ADD_TEST_SETUP_TEARDOWN_C("suiteName", "testName", testFunction, setupFunction, teardownFunction);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -77,7 +77,6 @@ To add a test with setup, teardown, and timeout:
         global_runner->runner.addTest(suite, test, func);
     }
 ```
-
 - **Null pointer check:** Checks if `global_runner` is *null*.
 - **Test addition:** Adds the test to the `runner` if `global_runner` is initialized.
 
@@ -91,7 +90,6 @@ To add a test with setup, teardown, and timeout:
         global_runner->runner.addTest(suite, test, func, nullptr, nullptr, std::chrono::seconds(timeout));
     }
 ```
-
 - *Timeout parameter:* Adds a timeout to the test in addition to the basic test addition steps.
 
 ### Test with Setup
@@ -104,5 +102,16 @@ To add a test with setup, teardown, and timeout:
         global_runner->runner.addTest(suite, test, func, setup);
     }
 ```
-
 - **Setup function:** Adds a setup function to be called before the test runs.
+
+### Test with Teardown
+```Cpp
+    void ADD_TEST_TEARDOWN_C(const char* suite, const char* test, void (*func)(void), void (*teardown)(void)) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, nullptr, teardown);
+    }
+```
+- **Teardown function:** Adds a teardown function to be called after the test runs.

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -21,3 +21,10 @@ To add a test with a timeout:
 ```C    
     ADD_TEST_TIMEOUT_C("suiteName", "testName", testFunction, timeoutInSeconds);
 ```
+
+### Test with Setup
+To add a test with a setup function:
+
+```C    
+    ADD_TEST_SETUP_C("suiteName", "testName", testFunction, setupFunction);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -2,3 +2,8 @@
 In this tutorial, you'll learn everything you need to know about the `ADD_TEST_C` function and its variants for adding tests in *C*.
 
 <br>
+
+## What is ADD_TEST_C?
+`ADD_TEST_C` and its variants are functions used to add tests to the `MusgraviteRunner` in the *C* environment. These functions ensure that tests are registered with various configurations such as setup, teardown, and timeout options.
+
+<br>

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -115,3 +115,15 @@ To add a test with setup, teardown, and timeout:
     }
 ```
 - **Teardown function:** Adds a teardown function to be called after the test runs.
+
+### Test with Setup and Teardown
+```Cpp
+    void ADD_TEST_SETUP_TEARDOWN_C(const char* suite, const char* test, void (*func)(void), void (*setup)(void), void (*teardown)(void)) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, setup, teardown);
+    }
+```
+- **Setup and Teardown functions:** Combines both setup and teardown functions for the test.

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -49,3 +49,10 @@ To add a test with both setup function and timeout:
 ```C
     ADD_TEST_SETUP_TIMEOUT_C("suiteName", "testName", testFunction, setupFunction, timeoutInSeconds);
 ```
+
+### Test with Teardown and Timeout
+To add a test with both teardown function and timeout:
+
+```C
+    ADD_TEST_TEARDOWN_TIMEOUT_C("suiteName", "testName", testFunction, teardownFunction, timeoutInSeconds);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -14,3 +14,10 @@ To add a basic test without setup, teardown, or timeout:
 ```C    
     ADD_TEST_C("suiteName", "testName", testFunction);
 ```
+
+### Test with Timeout
+To add a test with a timeout:
+
+```C    
+    ADD_TEST_TIMEOUT_C("suiteName", "testName", testFunction, timeoutInSeconds);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -42,3 +42,10 @@ To add a test with both setup and teardown functions:
 ```C    
     ADD_TEST_SETUP_TEARDOWN_C("suiteName", "testName", testFunction, setupFunction, teardownFunction);
 ```
+
+### Test with Setup and Timeout
+To add a test with both setup function and timeout:
+
+```C
+    ADD_TEST_SETUP_TIMEOUT_C("suiteName", "testName", testFunction, setupFunction, timeoutInSeconds);
+```

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -93,3 +93,16 @@ To add a test with setup, teardown, and timeout:
 ```
 
 - *Timeout parameter:* Adds a timeout to the test in addition to the basic test addition steps.
+
+### Test with Setup
+```Cpp
+    void ADD_TEST_SETUP_C(const char* suite, const char* test, void (*func)(void), void (*setup)(void)) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, setup);
+    }
+```
+
+- **Setup function:** Adds a setup function to be called before the test runs.

--- a/docs/C/examples/AddTests.md
+++ b/docs/C/examples/AddTests.md
@@ -80,3 +80,16 @@ To add a test with setup, teardown, and timeout:
 
 - **Null pointer check:** Checks if `global_runner` is *null*.
 - **Test addition:** Adds the test to the `runner` if `global_runner` is initialized.
+
+### Test with Timeout
+```Cpp
+    void ADD_TEST_TIMEOUT_C(const char* suite, const char* test, void (*func)(void), int timeout) {
+        if (global_runner == nullptr) {
+            return;
+        }
+
+        global_runner->runner.addTest(suite, test, func, nullptr, nullptr, std::chrono::seconds(timeout));
+    }
+```
+
+- *Timeout parameter:* Adds a timeout to the test in addition to the basic test addition steps.


### PR DESCRIPTION
This pull request adds detailed documentation for the ADD_TEST_C function and its variants. The documentation provides an overview of each function, implementation details, and important usage notes to ensure safe and efficient test registration with various configurations.

## Details
- **Overview of ADD_TEST_C and Variants:** Explains the purpose of each function and their role in adding tests with different configurations to the MusgraviteRunner.
- **Implementation Instructions:** Provides clear instructions on how to implement and use each ADD_TEST_C variant, including code snippets.
- **Function Breakdown:** Detailed explanation of what happens when each function is called, including null pointer checks, test addition, and optional setup, teardown, and timeout parameters.
- **Important Notes:** Highlights the necessity of calling initializeMusgraviteRunner before using any ADD_TEST_C functions and the safety checks performed.